### PR TITLE
Update Godot Minor Version

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="jigsaw"
 run/main_scene="res://assets/scenes/new_menu.tscn"
-config/features=PackedStringArray("4.4", "GL Compatibility")
+config/features=PackedStringArray("4.5", "GL Compatibility")
 config/icon="res://icon.svg"
 
 [autoload]


### PR DESCRIPTION
Updates godot minor version to 4.5, also a test
for how to push branches and approve PR's on git.