### PR TITLE
Make loading screen appear faster

### DIFF
--- a/assets/scenes/select_puzzle.tscn
+++ b/assets/scenes/select_puzzle.tscn
@@ -429,6 +429,12 @@ focus_mode = 0
 icon = ExtResource("9_i8mdc")
 flat = true
 
+[node name="LoadingScreen" type="Control" parent="."]
+visible = false
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
 [connection signal="pressed" from="Panel/VBoxContainer/Start_Puzzle" to="." method="_on_start_puzzle_pressed"]
 [connection signal="pressed" from="Panel/VBoxContainer/Go_Back" to="." method="_on_go_back_pressed"]
 [connection signal="pressed" from="GoBackToMenu" to="." method="_on_go_back_to_menu_pressed"]

--- a/assets/scripts/jigsaw_puzzle_1.gd
+++ b/assets/scripts/jigsaw_puzzle_1.gd
@@ -39,7 +39,9 @@ const BOX_FONT_COLOR = Color(0.95, 0.95, 0.95)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	# Render the loading screen immediately
 	loading.show()
+	await get_tree().process_frame 
 
 	name = "JigsawPuzzleNode"
 	selected_puzzle_dir = PuzzleVar.choice["base_file_path"] + "_" + str(PuzzleVar.choice["size"])

--- a/assets/scripts/select_puzzle.gd
+++ b/assets/scripts/select_puzzle.gd
@@ -24,6 +24,7 @@ var page_string = "%d out of %d"
 @onready var hbox = $"HBoxContainer"
 @onready var panel = $"Panel"
 @onready var thumbnail = $Panel/VBoxContainer/Thumbnail
+@onready var loading = $LoadingScreen
 
 # grid reference:
 #have an array of images to pull from that will correspond to an integer returned by the buttons
@@ -275,6 +276,8 @@ func add_custom_label(button, percentage):
 
 
 func _on_start_puzzle_pressed() -> void:
+	loading.show()  # show loading screen immediately
+	await get_tree().process_frame  # pause
 	get_tree().change_scene_to_file("res://assets/scenes/jigsaw_puzzle_1.tscn")
 
 


### PR DESCRIPTION
Loading screen now appears right after the user clicks start puzzle